### PR TITLE
sbgisen用設定の追加

### DIFF
--- a/turtle_nest/include/turtle_nest/generate_node.h
+++ b/turtle_nest/include/turtle_nest/generate_node.h
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  * ------------------------------------------------------------------
-*/
+ */
 
 #ifndef GENERATE_NODE_H
 #define GENERATE_NODE_H
@@ -24,6 +24,7 @@ void generate_python_node(QString workspace_path, QString package_name, QString 
 void create_init_file(QString node_dir);
 void add_py_node_to_cmake(QString c_make_file_path, QString package_name, QString node_name);
 void add_exec_permissions(QString node_path);
+void generate_cpp_header(QString package_path, QString node_name);
 void generate_cpp_node(QString package_path, QString node_name);
 
-#endif // GENERATE_NODE_H
+#endif  // GENERATE_NODE_H

--- a/turtle_nest/include/turtle_nest/string_tools.h
+++ b/turtle_nest/include/turtle_nest/string_tools.h
@@ -13,19 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  * ------------------------------------------------------------------
-*/
+ */
 
 #ifndef STRING_TOOLS_H
 #define STRING_TOOLS_H
 
 #include <QString>
 #include <QLineEdit>
+#include <ctime>
 
 QString escape_xml(QString input);
 bool is_valid_alphanumeric(QString string);
+int get_current_year();
 QString autocorrect_line_edit(QString text, QLineEdit* line_edit);
 QString autocorrect_string(QString string);
 bool is_valid_email(QString email);
 QString to_camel_case(const QString& snake_case);
 
-#endif // STRING_TOOLS_H
+#endif  // STRING_TOOLS_H

--- a/turtle_nest/src/generate_launch.cpp
+++ b/turtle_nest/src/generate_launch.cpp
@@ -16,7 +16,7 @@
 */
 
 #include "turtle_nest/generate_launch.h"
-
+#include "turtle_nest/string_tools.h"
 #include "turtle_nest/file_utils.h"
 #include <QFile>
 #include <QFileDialog>
@@ -46,15 +46,38 @@ void generate_launch_file(QString workspace_path, QString package_name, QString 
 
 QString generate_launch_text(QString package_name, QString node_name_cpp, QString node_name_python){
     std::ostringstream oss;
-    oss << R"(#!/usr/bin/env python3
+
+    QString license_text = QString(R"(#!/usr/bin/env python3
 # -*- encoding: utf-8 -*-
+# Copyright (c) %1 SoftBank Corp.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 """Launch file."""
 
 from launch import LaunchDescription
 from launch_ros.actions import Node
 
+
 def generate_launch_description() -> LaunchDescription:
-    return LaunchDescription([)";
+    """Generate launch description.
+
+    Returns:
+        LaunchDescription: Launch description.
+    """
+    return LaunchDescription([)").arg(get_current_year());
+
+    // Use a string stream to construct the rest of the launch text.
+    oss << license_text.toStdString();
 
     if (!node_name_cpp.isEmpty())
     oss << R"(

--- a/turtle_nest/src/generate_launch.cpp
+++ b/turtle_nest/src/generate_launch.cpp
@@ -46,10 +46,14 @@ void generate_launch_file(QString workspace_path, QString package_name, QString 
 
 QString generate_launch_text(QString package_name, QString node_name_cpp, QString node_name_python){
     std::ostringstream oss;
-    oss << R"(from launch import LaunchDescription
+    oss << R"(#!/usr/bin/env python3
+# -*- encoding: utf-8 -*-
+"""Launch file."""
+
+from launch import LaunchDescription
 from launch_ros.actions import Node
 
-def generate_launch_description():
+def generate_launch_description() -> LaunchDescription:
     return LaunchDescription([)";
 
     if (!node_name_cpp.isEmpty())

--- a/turtle_nest/src/generate_node.cpp
+++ b/turtle_nest/src/generate_node.cpp
@@ -29,7 +29,20 @@ void generate_python_node(QString workspace_path, QString package_name, QString 
 
     QString content = QString(R"(#!/usr/bin/env python3
 # -*- encoding: utf-8 -*-
-"""%1 node definition."""
+# Copyright (c) %3 SoftBank Corp.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""%2 node definition."""
 
 import rclpy
 from rclpy.node import Node
@@ -38,6 +51,7 @@ from std_msgs.msg import String
 
 
 class %2(Node):
+    """%2 node."""
 
     def __init__(self) -> None:
         """Constructor."""
@@ -45,8 +59,12 @@ class %2(Node):
         self.get_logger().info("Hello world from the Python node %1")
 
 
-def main(args=None) -> None:
-    """Run node."""
+def main(args: list | None = None) -> None:
+    """Run node.
+
+    Args:
+        args (list, optional): Command line arguments. Defaults to None.
+    """
     rclpy.init(args=args)
 
     %1 = %2()
@@ -62,7 +80,7 @@ def main(args=None) -> None:
 
 if __name__ == '__main__':
     main()
-)").arg(node_name, to_camel_case(node_name));;
+)").arg(node_name, to_camel_case(node_name)).arg(get_current_year());
 
     create_directory(node_dir);
     write_file(node_path, content);
@@ -107,7 +125,22 @@ void add_py_node_to_cmake(QString c_make_file_path, QString package_name, QStrin
 
 
 void generate_cpp_node(QString package_path, QString node_name){
-    QString content = QString(R"(#include "rclcpp/rclcpp.hpp"
+    QString content = QString(R"(/*********************************************************************
+ * Copyright (c) %3, SoftBank Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ********************************************************************/
+#include "rclcpp/rclcpp.hpp"
 #include "std_msgs/msg/string.hpp"
 
 class %2 : public rclcpp::Node
@@ -126,6 +159,6 @@ int main(int argc, char * argv[])
   rclcpp::spin(std::make_shared<%2>());
   rclcpp::shutdown();
   return 0;
-})").arg(node_name, to_camel_case(node_name));
+})").arg(node_name, to_camel_case(node_name)).arg(get_current_year());
     write_file(QDir(package_path).filePath("src/" + node_name + ".cpp"), content);
 }

--- a/turtle_nest/src/generate_node.cpp
+++ b/turtle_nest/src/generate_node.cpp
@@ -200,7 +200,7 @@ namespace %4
 int main(int argc, char * argv[])
 {
   rclcpp::init(argc, argv);
-  rclcpp::spin(std::make_shared<%2>());
+  rclcpp::spin(std::make_shared<%4::%2>());
   rclcpp::shutdown();
   return 0;
 })").arg(node_name, to_camel_case(node_name)).arg(get_current_year())

--- a/turtle_nest/src/generate_node.cpp
+++ b/turtle_nest/src/generate_node.cpp
@@ -28,6 +28,9 @@ void generate_python_node(QString workspace_path, QString package_name, QString 
     QString node_path = QDir(node_dir).filePath(node_name + ".py");
 
     QString content = QString(R"(#!/usr/bin/env python3
+# -*- encoding: utf-8 -*-
+"""%1 node definition."""
+
 import rclpy
 from rclpy.node import Node
 
@@ -36,12 +39,14 @@ from std_msgs.msg import String
 
 class %2(Node):
 
-    def __init__(self):
+    def __init__(self) -> None:
+        """Constructor."""
         super().__init__("%1")
         self.get_logger().info("Hello world from the Python node %1")
 
 
-def main(args=None):
+def main(args=None) -> None:
+    """Run node."""
     rclpy.init(args=args)
 
     %1 = %2()

--- a/turtle_nest/src/generate_node.cpp
+++ b/turtle_nest/src/generate_node.cpp
@@ -142,8 +142,8 @@ void generate_cpp_header(QString package_path, QString package_name, QString nod
 #ifndef %2_%3_HPP_
 #define %2_%3_HPP_
 
-#include "rclcpp/rclcpp.hpp"
-#include "std_msgs/msg/string.hpp"
+#include <rclcpp/rclcpp.hpp>
+#include <std_msgs/msg/string.hpp>
 
 namespace %4
 

--- a/turtle_nest/src/mainwindow.cpp
+++ b/turtle_nest/src/mainwindow.cpp
@@ -41,7 +41,7 @@ MainWindow::MainWindow(QWidget *parent)
     ui->createPackageButton->setVisible(false);
     ui->backButton->setVisible(false);
     QSettings settings("TurtleNest", "TurtleNest");
-    auto default_workspace_path = QDir::homePath() + "/ros2_ws/src/";
+    auto default_workspace_path = QDir::homePath() + "/ros/src/";
     ui->workspacePathEdit->setText(settings.value("workspace", default_workspace_path).toString());
     ui->packageNameShortWarn->setVisible(false);
     ui->packageNameEdit->setFocus();

--- a/turtle_nest/src/mainwindow.cpp
+++ b/turtle_nest/src/mainwindow.cpp
@@ -54,8 +54,8 @@ MainWindow::MainWindow(QWidget *parent)
 
     // Page 3
     ui->invalidEmailLabel->setVisible(false);
-    ui->maintainerEdit->setText(settings.value("maintainer_name", "").toString());
-    ui->emailEdit->setText(settings.value("maintainer_email", "").toString());
+    ui->maintainerEdit->setText(settings.value("maintainer_name", "SoftBank Corp.").toString());
+    ui->emailEdit->setText(settings.value("maintainer_email", "SBGRP-git@g.softbank.co.jp").toString());
 }
 
 

--- a/turtle_nest/src/rospkgcreator.cpp
+++ b/turtle_nest/src/rospkgcreator.cpp
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  * ------------------------------------------------------------------
-*/
+ */
 
 #include "turtle_nest/rospkgcreator.h"
 #include "turtle_nest/file_utils.h"
@@ -131,7 +131,7 @@ void RosPkgCreator::build_package() const{
     QDir dir(workspace_path);
     dir.cdUp();  // Get the path without /src extension to build in that location
 
-    QProcess builder;    
+    QProcess builder;
     builder.setProcessChannelMode(QProcess::MergedChannels);
     builder.setWorkingDirectory(dir.path());
 

--- a/turtle_nest/src/string_tools.cpp
+++ b/turtle_nest/src/string_tools.cpp
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  * ------------------------------------------------------------------
-*/
+ */
 
 #include "turtle_nest/string_tools.h"
 
@@ -49,6 +49,13 @@ bool is_valid_alphanumeric(QString string){
     return valid_input.match(string).hasMatch();
 }
 
+// Get the current year for the license info
+int get_current_year() {
+    std::time_t t = std::time(nullptr);
+    std::tm* tm = std::localtime(&t);
+    return 1900 + tm->tm_year;
+}
+
 QString autocorrect_line_edit(QString text, QLineEdit* line_edit){
     int cursor_pos = line_edit->cursorPosition();
     QString autocorrected_text = autocorrect_string(text);
@@ -68,7 +75,6 @@ QString autocorrect_string(QString string){
     static const QRegularExpression invalid_characters("[^a-z0-9_]");
     return string.toLower().replace(" ", "_").remove(invalid_characters);
 }
-
 
 QString to_camel_case(const QString& snake_case) {
     QStringList words = snake_case.split('_');

--- a/turtle_nest_tests/tst_ros_pkg_creator.cpp
+++ b/turtle_nest_tests/tst_ros_pkg_creator.cpp
@@ -94,7 +94,7 @@ QString read_xml_tag(const QString &filePath, const QString &tagName, const QStr
 
 QString get_tmp_workspace_path(){
     QTemporaryDir temp_dir;
-    return temp_dir.path() + "/ros2_ws/src";
+    return temp_dir.path() + "/ros/src";
 }
 
 bool dir_is_empty(const QString& dirPath) {
@@ -121,7 +121,7 @@ TEST(ros_pkg_creator, create_pkg_defaults){
 // Test the package creation with all the parameters
 TEST(ros_pkg_creator, create_pkg_all_values){
     QTemporaryDir temp_dir;
-    QString workspace_path = temp_dir.path() + "/ros2_ws";
+    QString workspace_path = temp_dir.path() + "/ros";
     QString package_path = workspace_path + "/src/package_name";
     QString xml_path = package_path + "/package.xml";
     RosPkgCreator pkg_creator(workspace_path + "/src", "package_name", CPP_AND_PYTHON);
@@ -245,5 +245,3 @@ TEST(ros_pkg_creator, cpp_python_with_both_nodes){
         "Hello world from the Python node python_node"
         ));
 }
-
-


### PR DESCRIPTION
## Summary

sbgisenでパッケージを作るときに便利なように一部設定を変更

- パッケージを生成する際にノードとlaunchファイルにライセンス情報が付与されるように修正
- ライセンス作成時に西暦を反映するための関数を追加
- Pythonファイルについてはlinterエラー回避のため型アノテーションとコードドキュメントを追加
- maintainer入力時にデフォルトがsbgisenのものになるように修正（なお、本GUIは最後に入力した際の値を`~/.config/TurtleNest/TurtleNest.conf`に保存する）
- デフォルトワークスペースを`~/ros`に変更